### PR TITLE
Inclusão método PATCH

### DIFF
--- a/src/ApiPix/types/apipix-types.ts
+++ b/src/ApiPix/types/apipix-types.ts
@@ -24,7 +24,7 @@ export type Values = string | boolean
 export type Props<T> = keyof T
 // export type Props = keyof IApiPixConfig
 
-export type ApiMethod = 'post' | 'get' | 'put'
+export type ApiMethod = 'post' | 'get' | 'put' | 'patch'
 
 export interface ICancelSource {
   idToken: CancelToken | string


### PR DESCRIPTION
A API da GerenciaNet possui métodos do tipo PATCH porém eles não estão mapeados para conseguir usarmos na função "requestApi" que é extremamente util pois caso um endpoint não esteja explicitamente no package, conseguimos usar essa função para usar qualquer outro método não mapeado da API PIX da GerenciaNet